### PR TITLE
fix: serialise mypy pre-commit hook (parallel batches race on .mypy_cache)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,6 +40,11 @@ repos:
         name: mypy
         entry: poetry run mypy
         language: system
+        # Without require_serial, pre-commit splits the file list into parallel
+        # batches, and concurrent mypy processes race on the shared .mypy_cache —
+        # INTERNAL ERROR on a cold cache (reproducible: rm -rf .mypy_cache, run
+        # --all-files). One serial invocation is also what mirrors-mypy ships.
+        require_serial: true
         types: [python]
         files: ^easy_icons/
   - repo: local


### PR DESCRIPTION
## Summary
Propagates the mypy-hook fix just merged in django-content-license (SamuelJennings/django-content-license#31). This repo carries the identical vulnerable hook config; its green Code Quality runs so far have been timing luck.

## Root cause
Without `require_serial`, pre-commit splits the hook's file list into **parallel batches** and runs **concurrent mypy processes sharing one `.mypy_cache`**. On a cold cache (every CI run — CI only caches `~/.cache/pre-commit`) the processes write cache entries for the same modules and collide; one crashes with mypy 1.20.2 `INTERNAL ERROR`, failing the required Code Quality check on unrelated PRs. Reproduced and fixed in the sibling repo; same hook, same race here.

## Change
One hook setting in `.pre-commit-config.yaml`: `require_serial: true` on the mypy hook — a single mypy invocation over all files, no concurrent cache access. Matches what the official `mirrors-mypy` hook ships. Incremental caching stays on for local speed.

## Verify evidence
- **5/5 cold-cache runs pass** locally (`rm -rf .mypy_cache && pre-commit run mypy --all-files`).
- verify: lint skipped (CI-tier) · typecheck passed · test passed · build passed; tamper-check clean (0 flags).
- Config-only, no behaviour to test — stated rather than skipped silently.

## Lane: quickfix
One line of hook config, single concern, no code/API/data/security surface.

## Risk
None identified — serialising the hook only changes execution strategy; mypy's results are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)