### PR TITLE
docs: align constitution Article VII to family standard v0.2.0

### DIFF
--- a/memory/constitution.md
+++ b/memory/constitution.md
@@ -43,7 +43,7 @@ it renders on the package index.
 
 ### Article VII — Dependency discipline
 A new runtime dependency requires a stated justification (Simplicity applied to the dependency
-tree; prefer the shared `fairdm-dev-tools` toolchain over ad-hoc dev deps). `deptry` must
+tree; prefer the shared `mvp-shared` toolchain bundle over ad-hoc dev deps). `deptry` must
 pass: no unused, missing, or transitively-relied-upon dependencies.
 
 ## Project articles


### PR DESCRIPTION
**Summary** — Re-sync the materialized constitution prose to the v0.2.0 toolchain: Article VII should name the current shared bundle.

**Change** — `memory/constitution.md` Article VII (Dependency discipline): `fairdm-dev-tools` → `mvp-shared` toolchain bundle. Docs-only; the actual dependency already moved to `mvp-shared @v0.2.0` in #48.

**Verify evidence** — `verify.sh`: lint passed · typecheck passed · test passed · build passed (4/4). tamper-check: clean (0 flags).

**Lane: quickfix** — Single-concern, one-file docs prose fix; no code, no public interface, no data/schema/security surface. Well inside the fast-lane ceiling.

**Risk** — None. Prose-only; no behavioural change.